### PR TITLE
Tracing integration rpc span

### DIFF
--- a/beacon_node/network/src/sync/tests/lookups.rs
+++ b/beacon_node/network/src/sync/tests/lookups.rs
@@ -36,9 +36,9 @@ use lighthouse_network::{
     types::SyncState,
     NetworkConfig, NetworkGlobals, PeerId,
 };
-use tracing::info;
 use slot_clock::{SlotClock, TestingSlotClock};
 use tokio::sync::mpsc;
+use tracing::info;
 use types::{
     data_column_sidecar::ColumnIndex,
     test_utils::{SeedableRng, TestRandom, XorShiftRng},

--- a/slasher/service/src/service.rs
+++ b/slasher/service/src/service.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use task_executor::TaskExecutor;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::time::{interval_at, Duration, Instant};
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, trace, warn, Instrument};
 use types::{AttesterSlashing, Epoch, EthSpec, ProposerSlashing};
 
 pub struct SlasherService<T: BeaconChainTypes> {
@@ -64,12 +64,16 @@ impl<T: BeaconChainTypes> SlasherService<T> {
                 update_period,
                 slot_offset,
                 notif_sender,
-            ),
+            )
+            .instrument(tracing::trace_span!("", service = "slasher")),
             "slasher_server_notifier",
         );
 
         executor.spawn_blocking(
-            || Self::run_processor(beacon_chain, slasher, notif_receiver, network_sender),
+            || {
+                let _ = Self::run_processor(beacon_chain, slasher, notif_receiver, network_sender)
+                    .instrument(tracing::trace_span!("", service = "slasher"));
+            },
             "slasher_server_processor",
         );
 

--- a/slasher/service/src/service.rs
+++ b/slasher/service/src/service.rs
@@ -65,14 +65,14 @@ impl<T: BeaconChainTypes> SlasherService<T> {
                 slot_offset,
                 notif_sender,
             )
-            .instrument(tracing::trace_span!("", service = "slasher")),
+            .instrument(tracing::info_span!("", service = "slasher")),
             "slasher_server_notifier",
         );
 
         executor.spawn_blocking(
             || {
                 let _ = Self::run_processor(beacon_chain, slasher, notif_receiver, network_sender)
-                    .instrument(tracing::trace_span!("", service = "slasher"));
+                    .instrument(tracing::info_span!("slasher", service = "slasher"));
             },
             "slasher_server_processor",
         );

--- a/slasher/src/slasher.rs
+++ b/slasher/src/slasher.rs
@@ -11,7 +11,7 @@ use crate::{
 use parking_lot::Mutex;
 use std::collections::HashSet;
 use std::sync::Arc;
-use tracing::{debug, error, info, span, Level};
+use tracing::{debug, error, info};
 use types::{
     AttesterSlashing, ChainSpec, Epoch, EthSpec, IndexedAttestation, ProposerSlashing,
     SignedBeaconBlockHeader,
@@ -29,9 +29,6 @@ pub struct Slasher<E: EthSpec> {
 
 impl<E: EthSpec> Slasher<E> {
     pub fn open(config: Config, spec: Arc<ChainSpec>) -> Result<Self, Error> {
-        let span = span!(Level::INFO, "Slasher", service = "slasher");
-        let _enter = span.enter();
-
         config.validate()?;
         let config = Arc::new(config);
         let db = SlasherDB::open(config.clone(), spec)?;


### PR DESCRIPTION
Since the rpc service is a rust-libp2p `Behaviour` the actual service is spawned within the rust-libp2p crate. Attaching the span to that future isn't possible within the lighthouse crate. Instead we use the `instrument` attribute macro on each `Rpc` method defined within the `RPC` impl.

This also contains the changes from the slasher span PR
